### PR TITLE
relative advanced bite point mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Configuration (please complete the following information):**
+ - Wheelbase: [e.g. OSW]
+ - Rim: [e.g. BMW GT2, Formula]
+ - Teensy Board: [e.g. LC, 31 or 32]
+ - Firmware type: [e.g. BT, USB]
+ - Firmware version, if known: 
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Regarding the newly introduced advanced bite point modes with the McLaren wheel.

Not sure if I'm doing this (pull request) right, but I'd like to ask if it is possible to slightly change the advanced bite point mode. 

For now, it is working as an upper deadzone. E.g. when you "reduced" the input to 70 %, you'll get a change of input with the paddle pressed 70 % or less. 

What I'd like to see is the following: let's still assume we set the bite point to 70 %. When I release the paddle now, it would be nice to have a change in input immediately:

set to 70% -> physical releasing of 10 % -> 70% - (10% * 70%) = 63% input (where input with the current method would still be 70%; 50% release would give us 35% compared to 50%, etc)

It's just an idea and I assume you did already think of something alike, but I guess it's done as it is now for technical reasons. 

(Another great addition would be output of the "bite point" setting when turning the Funky Switch; but again, I guess it has already been considered and isn't in for technical reasons)